### PR TITLE
Keep emptied values empty

### DIFF
--- a/src/post-processors/key-as-default-value.post-processor.ts
+++ b/src/post-processors/key-as-default-value.post-processor.ts
@@ -5,6 +5,6 @@ export class KeyAsDefaultValuePostProcessor implements PostProcessorInterface {
 	public name: string = 'KeyAsDefaultValue';
 
 	public process(draft: TranslationCollection, extracted: TranslationCollection, existing: TranslationCollection): TranslationCollection {
-		return draft.map((key, val) => (val === '' ? key : val));
+		return draft.map((key, val) => (val === '' && existing.get(key) === undefined ? key : val));
 	}
 }


### PR DESCRIPTION
When running the extract command with the `--key-as-default-value` flag active, empty strings will remain empty while new keys are added with the key as their value.